### PR TITLE
fix: app now stops on Ctrl+C when running in Docker

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -4,4 +4,4 @@ set -e
 
 export NODE_OPTIONS="--import ./instrument.js"
 
-fastify start server/plugin.js -a 0.0.0.0 -l info | pino-pretty -S
+exec fastify start server/plugin.js -a 0.0.0.0 -l info -o

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -55,10 +55,13 @@ export default (app, _options) => {
   return app;
 };
 
-// export const options = {
-//   logger: {
-//     options: {
-//       singleLine: true,
-//     },
-//   },
-// };
+export const options = {
+  logger: {
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        singleLine: true,
+      },
+    },
+  },
+};


### PR DESCRIPTION
Replace shell pipeline (| pino-pretty) with fastify-cli's built-in options loading (-o). The logger transport with pino-pretty (singleLine) is configured via the exported 'options' constant in server/plugin.js.

Using 'exec' makes fastify PID 1, so Docker signals (SIGINT/SIGTERM) are delivered directly to the Node.js process instead of being lost by the shell.

Closes #11


Rebuild the image before running

```
$ docker run -p 3000:3000 -e SERVER_MESSAGE="Hexlet Awesome Server" -e SENTRY_DSN="<your dsn>" hexletcomponents/devops-example-app
[17:16:29.427] INFO (1): incoming request {"reqId":"req-5","req":{"method":"GET","url":"/assets/css/bootstrap.min.css.map","host":"localhost:3000","remoteAddress":"172.17.0.1","remotePort":32854}}
[17:16:29.429] INFO (1): request completed {"reqId":"req-5","res":{"statusCode":200},"responseTime":1.9774219989776611}
[17:16:29.461] INFO (1): incoming request {"reqId":"req-6","req":{"method":"GET","url":"/favicon.ico","host":"localhost:3000","remoteAddress":"172.17.0.1","remotePort":32854}}
[17:16:29.461] INFO (1): Route GET:/favicon.ico not found {"reqId":"req-6"}
[17:16:29.462] INFO (1): request completed {"reqId":"req-6","res":{"statusCode":404},"responseTime":0.43787600100040436}
^CReceived signal SIGINT
[17:16:32.880] WARN (1): Closed
```